### PR TITLE
Fix warnings found by espidf

### DIFF
--- a/ESP/lib/src/data/utilities/network_utilities.cpp
+++ b/ESP/lib/src/data/utilities/network_utilities.cpp
@@ -77,20 +77,28 @@ void Network_Utilities::checkWiFiState()
     {
         case wl_status_t::WL_IDLE_STATUS:
             wifiStateManager.setState(WiFiState_e::WiFiState_Idle);
+            break;
         case wl_status_t::WL_NO_SSID_AVAIL:
             wifiStateManager.setState(WiFiState_e::WiFiState_Error);
+            break;
         case wl_status_t::WL_SCAN_COMPLETED:
             wifiStateManager.setState(WiFiState_e::WiFiState_None);
+            break;
         case wl_status_t::WL_CONNECTED:
             wifiStateManager.setState(WiFiState_e::WiFiState_Connected);
+            break;
         case wl_status_t::WL_CONNECT_FAILED:
             wifiStateManager.setState(WiFiState_e::WiFiState_Error);
+            break;
         case wl_status_t::WL_CONNECTION_LOST:
             wifiStateManager.setState(WiFiState_e::WiFiState_Disconnected);
+            break;
         case wl_status_t::WL_DISCONNECTED:
             wifiStateManager.setState(WiFiState_e::WiFiState_Disconnected);
+            break;
         default:
             wifiStateManager.setState(WiFiState_e::WiFiState_Disconnected);
+            break;
     }
 }
 

--- a/ESP/lib/src/network/api/baseAPI/baseAPI.cpp
+++ b/ESP/lib/src/network/api/baseAPI/baseAPI.cpp
@@ -176,7 +176,7 @@ void BaseAPI::setDeviceConfig(AsyncWebServerRequest* request) {
       std::string service;
       std::string ota_password;
       std::string ota_login;
-      int ota_port;
+      int ota_port = 0;
 
       for (int i = 0; i < params; i++) {
         AsyncWebParameter* param = request->getParam(i);

--- a/ESP/lib/src/network/api/baseAPI/baseAPI.cpp
+++ b/ESP/lib/src/network/api/baseAPI/baseAPI.cpp
@@ -204,6 +204,12 @@ void BaseAPI::setDeviceConfig(AsyncWebServerRequest* request) {
       projectConfig.setMDNSConfig(hostname, service, true);
       request->send(200, MIMETYPE_JSON,
                     "{\"msg\":\"Done. Device Config has been set.\"}");
+      break;
+    }
+    default: {
+      request->send(400, MIMETYPE_JSON, "{\"msg\":\"Invalid Request\"}");
+      request->redirect("/");
+      break;
     }
   }
 }
@@ -242,6 +248,12 @@ void BaseAPI::setWiFiTXPower(AsyncWebServerRequest* request) {
       projectConfig.wifiTxPowerConfigSave();
       request->send(200, MIMETYPE_JSON,
                     "{\"msg\":\"Done. TX Power has been set.\"}");
+      break;
+    }
+    default: {
+      request->send(400, MIMETYPE_JSON, "{\"msg\":\"Invalid Request\"}");
+      request->redirect("/");
+      break;
     }
   }
 }
@@ -251,6 +263,7 @@ void BaseAPI::rebootDevice(AsyncWebServerRequest* request) {
     case GET: {
       request->send(200, MIMETYPE_JSON, "{\"msg\":\"Rebooting Device\"}");
       OpenIrisTasks::ScheduleRestart(2000);
+      break;
     }
     default: {
       request->send(400, MIMETYPE_JSON, "{\"msg\":\"Invalid Request\"}");
@@ -265,6 +278,7 @@ void BaseAPI::factoryReset(AsyncWebServerRequest* request) {
       log_d("Factory Reset");
       projectConfig.reset();
       request->send(200, MIMETYPE_JSON, "{\"msg\":\"Factory Reset\"}");
+      break;
     }
     default: {
       request->send(400, MIMETYPE_JSON, "{\"msg\":\"Invalid Request\"}");

--- a/ESP/lib/src/network/stream/streamServer.cpp
+++ b/ESP/lib/src/network/stream/streamServer.cpp
@@ -47,7 +47,7 @@ esp_err_t StreamHelpers::stream(httpd_req_t *req)
             res = httpd_resp_send_chunk(req, STREAM_BOUNDARY, strlen(STREAM_BOUNDARY));
         if (res == ESP_OK)
         {
-            size_t hlen = snprintf((char *)part_buf, 128, STREAM_PART, _jpg_buf_len, _timestamp.tv_sec, _timestamp.tv_usec);
+            size_t hlen = snprintf((char *)part_buf, 128, STREAM_PART, _jpg_buf_len, static_cast<int>(_timestamp.tv_sec), static_cast<int>(_timestamp.tv_usec % 1000000));
             res = httpd_resp_send_chunk(req, (const char *)part_buf, hlen);
         }
         if (res == ESP_OK)

--- a/ESP/lib/src/network/stream/streamServer.hpp
+++ b/ESP/lib/src/network/stream/streamServer.hpp
@@ -10,7 +10,6 @@
 #include "esp_camera.h"
 #include "esp_http_server.h"
 #include "esp_timer.h"
-#include "fb_gfx.h"
 #include "img_converters.h"
 
 namespace StreamHelpers


### PR DESCRIPTION
I recently converted this repo to `framework = arduino, espidf` locally, and while that version is still pretty rough, the `espidf` compiler gave a bunch of helpful warnings about the existing code. I've done my best to fix them in this PR. (Everything except [Remove unused fb_gfx](https://github.com/EyeTrackVR/OpenIris/commit/eb2b5c551fc593a750e703b2686455365cb962cb) is based on a warning from `espidf`.)