### PR TITLE
Fix the serial command manager preventing the boards from connecting to wi-fi

### DIFF
--- a/ESP/ini/dev_config.ini
+++ b/ESP/ini/dev_config.ini
@@ -42,6 +42,7 @@ build_flags =
 	'-DWIFI_AP_SSID=${wifi.ap_ssid}'
 	'-DWIFI_AP_PASSWORD=${wifi.ap_password}'
 	'-DWIFI_AP_CHANNEL=${wifi.adhocchannel}'
+	'-DSERIAL_FLUSH_ENABLED=${development.serial_flush_enabled}'
 
 	'-DOTA_PASSWORD=${ota.otapassword}'    ; Set the OTA password
 	'-DOTA_LOGIN=${ota.otalogin}'

--- a/ESP/ini/user_config.ini
+++ b/ESP/ini/user_config.ini
@@ -15,3 +15,6 @@ adhocchannel = 1
 [ota]
 otalogin = "openiris"
 otapassword = "12345678"
+
+[development]
+serial_flush_enabled = 0

--- a/ESP/lib/src/io/Serial/SerialManager.cpp
+++ b/ESP/lib/src/io/Serial/SerialManager.cpp
@@ -58,9 +58,6 @@ void SerialManager::init() {
 }
 
 void SerialManager::run() {
-  while (true) {
-    // we're getting a command, read it whole and process.
-    // otherwise, send a frame if we're supposed to
     if (Serial.available()) {
       JsonDocument doc;
       DeserializationError deserializationError = deserializeJson(doc, Serial);
@@ -68,7 +65,6 @@ void SerialManager::run() {
       if (deserializationError) {
         log_e("Command deserialization failed: %s",
               deserializationError.c_str());
-        continue;
       }
 
       Command command = {doc};
@@ -79,5 +75,4 @@ void SerialManager::run() {
       this->send_frame();
     }
 #endif
-  }
 }

--- a/ESP/lib/src/io/Serial/SerialManager.cpp
+++ b/ESP/lib/src/io/Serial/SerialManager.cpp
@@ -54,7 +54,9 @@ void SerialManager::send_frame() {
 
 void SerialManager::init() {
   Serial.begin(3000000);
-  Serial.flush();
+  if (SERIAL_FLUSH_ENABLED){
+    Serial.flush();
+  }
 }
 
 void SerialManager::run() {


### PR DESCRIPTION
Fixes the issues with the tracker boards not connecting to Wi-Fi when powered up without being connected to a serial monitor. 

A leftover from the initial implementation was preventing the loop() function from ever returning control once the serial command manager tried to receive a command.  