### PR TITLE
Feature/add serial mdns command

### DIFF
--- a/ESP/ini/dev_config.ini
+++ b/ESP/ini/dev_config.ini
@@ -43,10 +43,8 @@ build_flags =
 	'-DWIFI_AP_PASSWORD=${wifi.ap_password}'
 	'-DWIFI_AP_CHANNEL=${wifi.adhocchannel}'
 
-	-DOTA_SERVER_PORT=${ota.otaserverport}
 	'-DOTA_PASSWORD=${ota.otapassword}'    ; Set the OTA password
 	'-DOTA_LOGIN=${ota.otalogin}'
-	'-DOTA_IP=${ota.otaserverip}'          ; Set the OTA password
 
 	-O2                    ; optimize for speed
 	-DASYNCWEBSERVER_REGEX ; enable regex in asyncwebserver

--- a/ESP/ini/sim.ini
+++ b/ESP/ini/sim.ini
@@ -21,11 +21,9 @@ build_flags = -DENABLE_ADHOC=${wifi.enableadhoc}
 			  '-DWIFI_AP_CHANNEL=${wifi.adhocchannel}'
 			  '-DVERSION=""'
 
-			  -DOTA_SERVER_PORT=${ota.otaserverport}
 			  '-DOTA_PASSWORD=${ota.otapassword}'    ; Set the OTA password
 			  '-DOTA_LOGIN=${ota.otalogin}'
-			  '-DOTA_IP=${ota.otaserverip}'          ; Set the OTA password
-
+			 
 			  -O2                    ; optimize for speed
 			  -DASYNCWEBSERVER_REGEX ; enable regex in asyncwebserver
 

--- a/ESP/ini/user_config.ini
+++ b/ESP/ini/user_config.ini
@@ -13,7 +13,5 @@ enableadhoc = 0
 adhocchannel = 1
 
 [ota]
-otaserverip = "openiristracker.local"
 otalogin = "openiris"
 otapassword = "12345678"
-otaserverport = 3232

--- a/ESP/lib/src/data/CommandManager/CommandManager.cpp
+++ b/ESP/lib/src/data/CommandManager/CommandManager.cpp
@@ -13,43 +13,62 @@ const CommandType CommandManager::getCommandType(Command &command){
     return CommandType::None;
 }
 
+bool CommandManager::hasHasDataField(Command &command) {
+    return command.data.containsKey("data");
+}
 
 void CommandManager::handleCommand(Command command) {
     auto command_type = this->getCommandType(command); 
 
-    if (!command.data.containsKey("data"))
-        // malformed command, lacked data field
-        return; 
-
     switch(command_type)
     {
-    case CommandType::SET_WIFI: {
-        if(!command.data["data"].containsKey("ssid") || !command.data["data"].containsKey("password"))
+        case CommandType::SET_WIFI: {
+            if (!this->hasHasDataField(command))
+                // malformed command, lacked data field
+                break; 
+
+
+            if(!command.data["data"].containsKey("ssid") || !command.data["data"].containsKey("password"))
+                break;
+
+            std::string customNetworkName = "main";
+            if (command.data["data"].containsKey("network_name"))
+                customNetworkName = command.data["data"]["network_name"].as<std::string>();
+
+            this->deviceConfig->setWifiConfig(
+                customNetworkName,
+                command.data["data"]["ssid"],
+                command.data["data"]["password"],
+                0, // channel, should this be zero?
+                0, // power, should this be zero? 
+                false, 
+                false
+            );
+            
+            // we purposefully save here
+            this->deviceConfig->save();
             break;
+        }
+        case CommandType::SET_MDNS: {
+            if (!this->hasHasDataField(command))
+                break;
 
-        std::string customNetworkName = "main";
-        if (command.data["data"].containsKey("network_name"))
-            customNetworkName = command.data["data"]["network_name"].as<std::string>();
+            if(!command.data["data"].containsKey("hostname") || !strlen(command.data["data"]["hostname"]))
+                break;
 
-        this->deviceConfig->setWifiConfig(
-            customNetworkName,
-            command.data["data"]["ssid"],
-            command.data["data"]["password"],
-            0, // channel, should this be zero?
-            0, // power, should this be zero? 
-            false, 
-            false
-        );
-        
-        // we purposefully save here
-        this->deviceConfig->save();
-        break;
-    }
-    case CommandType::PING: {
-        Serial.println("PONG \n\r");
-        break;
-    }
-    default:
-        break;
+            this->deviceConfig->setMDNSConfig(
+                command.data["data"]["hostname"],
+                "openiristracker",
+                false
+            );
+
+            break;
+        }
+        case CommandType::PING: {
+            Serial.println("PONG \n\r");
+            break;
+        }
+        default:
+            break;
     }
 }

--- a/ESP/lib/src/data/CommandManager/CommandManager.hpp
+++ b/ESP/lib/src/data/CommandManager/CommandManager.hpp
@@ -9,6 +9,7 @@ enum CommandType {
     None,
     PING,
     SET_WIFI,
+    SET_MDNS,
 };
 
 
@@ -22,9 +23,12 @@ private:
 const std::unordered_map<std::string, CommandType> commandMap = {
     {"ping", CommandType::PING},
     {"set_wifi", CommandType::SET_WIFI},
+    {"set_mdns", CommandType::SET_MDNS},
 };
 
 ProjectConfig* deviceConfig;
+
+bool hasHasDataField(Command &command);
 
 public:
     CommandManager(ProjectConfig *deviceConfig); 

--- a/ESP/lib/src/io/Serial/SerialManager.cpp
+++ b/ESP/lib/src/io/Serial/SerialManager.cpp
@@ -61,7 +61,7 @@ void SerialManager::run() {
   while (true) {
     // we're getting a command, read it whole and process.
     // otherwise, send a frame if we're supposed to
-    if (Serial.available()) {      
+    if (Serial.available()) {
       JsonDocument doc;
       DeserializationError deserializationError = deserializeJson(doc, Serial);
 
@@ -70,7 +70,7 @@ void SerialManager::run() {
               deserializationError.c_str());
         continue;
       }
-      
+
       Command command = {doc};
       this->commandManager->handleCommand(command);
     }

--- a/ESP/lib/src/network/mDNS/MDNSManager.cpp
+++ b/ESP/lib/src/network/mDNS/MDNSManager.cpp
@@ -19,6 +19,7 @@ bool MDNSHandler::startMDNS() {
   //! Add service needs leading _ on ESP32 implementation for some reason
   //! (according to the docs)
   MDNS.addServiceTxt(service.c_str(), "_tcp", "stream_port", "80");
+  MDNS.addServiceTxt(service.c_str(), "_tcp", "api_port", "81");
   log_i("MDNS initialized!");
   mdnsStateManager.setState(MDNSState_e::MDNSState_Started);
   return true;


### PR DESCRIPTION
Adds a `SET_MDNS `serial command so that the flasher can setup and/or update the MDNS name of the device.

 Currently, the only way to update it  is to use the API, with this, the user will be able to set a custom name for each of their trackers simply during the initial setup.

The command data looks very similar to what `SET_WIFI`:

```json
{
   "command":"set_mdns",
   "data":{
      "hostname":"name"
   }
}
```

Additionally I cleaned up some leftover from the initial OTA / MDNS implementation, as well as exposed the OTA port in MDNS services 