### PR TITLE
Fix invalid HTTP header

### DIFF
--- a/ESP/lib/src/network/stream/streamServer.cpp
+++ b/ESP/lib/src/network/stream/streamServer.cpp
@@ -25,7 +25,7 @@ esp_err_t StreamHelpers::stream(httpd_req_t *req)
     if (res != ESP_OK)
         return res;
 
-    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin; Content-Type: multipart/x-mixed-replace; boundary=123456789000000000000987654321\r\n", "*");
+    httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*");
     httpd_resp_set_hdr(req, "X-Framerate", "60");
 
     while (true)


### PR DESCRIPTION
The content type header is already set above. This change fixes a failure when parsing headers with certain HTTP clients.

Before:
```
*   Trying 192.168.0.225:80...
* Connected to 192.168.0.225 (192.168.0.225) port 80
> GET / HTTP/1.1
> Host: 192.168.0.225
> User-Agent: curl/8.6.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: multipart/x-mixed-replace;boundary=123456789000000000000987654321
< Transfer-Encoding: chunked
< Access-Control-Allow-Origin; Content-Type: multipart/x-mixed-replace; boundary=123456789000000000000987654321
< : *
< X-Framerate: 60
```

After:
```
*   Trying 192.168.0.227:80...
* Connected to 192.168.0.227 (192.168.0.227) port 80
> GET / HTTP/1.1
> Host: 192.168.0.227
> User-Agent: url/8.6.0 
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: multipart/x-mixed-replace;boundary=123456789000000000000987654321
< Transfer-Encoding: chunked
< Access-Control-Allow-Origin: *
< X-Framerate: 60
```