### PR TITLE
Is this an intentional fallthrough?

### DIFF
--- a/ESP/lib/src/data/utilities/network_utilities.cpp
+++ b/ESP/lib/src/data/utilities/network_utilities.cpp
@@ -77,18 +77,25 @@ void Network_Utilities::checkWiFiState()
     {
         case wl_status_t::WL_IDLE_STATUS:
             wifiStateManager.setState(WiFiState_e::WiFiState_Idle);
+            break;
         case wl_status_t::WL_NO_SSID_AVAIL:
             wifiStateManager.setState(WiFiState_e::WiFiState_Error);
+            break;
         case wl_status_t::WL_SCAN_COMPLETED:
             wifiStateManager.setState(WiFiState_e::WiFiState_None);
+            break;
         case wl_status_t::WL_CONNECTED:
             wifiStateManager.setState(WiFiState_e::WiFiState_Connected);
+            break;
         case wl_status_t::WL_CONNECT_FAILED:
             wifiStateManager.setState(WiFiState_e::WiFiState_Error);
+            break;
         case wl_status_t::WL_CONNECTION_LOST:
             wifiStateManager.setState(WiFiState_e::WiFiState_Disconnected);
+            break;
         case wl_status_t::WL_DISCONNECTED:
             wifiStateManager.setState(WiFiState_e::WiFiState_Disconnected);
+            break;
         default:
             wifiStateManager.setState(WiFiState_e::WiFiState_Disconnected);
     }


### PR DESCRIPTION
Fix implicit fallthrough warning in checkWiFiState switch statement

If these changes were intentional and the fallthroughs were meant to be implicit, please disregard this PR 👍 