### PR TITLE
feat: Add camera resolution configuration support

### DIFF
--- a/ESP/ini/dev_config.ini
+++ b/ESP/ini/dev_config.ini
@@ -46,6 +46,7 @@ build_flags =
 
 	'-DOTA_PASSWORD=${ota.otapassword}'    ; Set the OTA password
 	'-DOTA_LOGIN=${ota.otalogin}'
+	'-DCAM_RESOLUTION=${cam.resolution}'
 
 	-O2                    ; optimize for speed
 	-DASYNCWEBSERVER_REGEX ; enable regex in asyncwebserver

--- a/ESP/ini/user_config.ini
+++ b/ESP/ini/user_config.ini
@@ -18,3 +18,6 @@ otapassword = "12345678"
 
 [development]
 serial_flush_enabled = 0
+
+[cam]
+resolution = FRAMESIZE_240X240

--- a/ESP/lib/src/data/config/project_config.cpp
+++ b/ESP/lib/src/data/config/project_config.cpp
@@ -1,4 +1,5 @@
 #include "project_config.hpp"
+#include "sensor.h"
 
 ProjectConfig::ProjectConfig(const std::string& name,
                              const std::string& mdnsName)
@@ -53,7 +54,7 @@ void ProjectConfig::initConfig() {
   this->config.camera = {
       .vflip = 0,
       .href = 0,
-      .framesize = 4,
+      .framesize = (uint8_t)CAM_RESOLUTION,
       .quality = 7,
       .brightness = 2,
   };
@@ -200,7 +201,7 @@ void ProjectConfig::load() {
   /* Camera Config */
   this->config.camera.vflip = getInt("vflip", 0);
   this->config.camera.href = getInt("href", 0);
-  this->config.camera.framesize = getInt("framesize", 4);
+  this->config.camera.framesize = getInt("framesize", (uint8_t)CAM_RESOLUTION);
   this->config.camera.quality = getInt("quality", 7);
   this->config.camera.brightness = getInt("brightness", 2);
 

--- a/ESP/lib/src/io/camera/cameraHandler.cpp
+++ b/ESP/lib/src/io/camera/cameraHandler.cpp
@@ -63,7 +63,7 @@ void CameraHandler::setupCameraPinout() {
 
 void CameraHandler::setupBasicResolution() {
   config.pixel_format = PIXFORMAT_JPEG;
-  config.frame_size = FRAMESIZE_240X240;
+  config.frame_size = CAM_RESOLUTION;
 
   if (!psramFound()) {
     log_e("[Camera]: Did not find psram, setting lower image quality");


### PR DESCRIPTION
In this Pr, the user can configure the resolution of the camera transmission through the user_config.ini's [cam] in the resolution, mainly to be able to get the full-size frame ratio, not only 1:1.

Usage Example:

```ini
[cam]
resolution = FRAMESIZE_QVGA
```

The above setting would configure the camera to transmit at a resolution of 320x240 pixels, which corresponds to a 4:3 aspect ratio.